### PR TITLE
Prevents hash fragment in URLs from being parsed

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var htmlMinifier = require("html-minifier");
 var attrParse = require("./lib/attributesParser");
 var SourceNode = require("source-map").SourceNode;
 var loaderUtils = require("loader-utils");
+var url = require("url");
 
 function randomIdent() {
 	return "xxxHTMLLINKxxx" + Math.random() + Math.random() + "xxx";
@@ -35,6 +36,15 @@ module.exports = function(content) {
 	content = [content];
 	links.forEach(function(link) {
 		if(!loaderUtils.isUrlRequest(link.value, root)) return;
+        
+		var uri = url.parse(link.value);
+		if (uri.hash !== null && uri.hash !== undefined) {
+		    uri.hash = null;
+		    link.value = uri.format();
+		    link.length = link.value.length;
+		}
+
+        
 		do {
 			var ident = randomIdent();
 		} while(data[ident]);

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -53,4 +53,9 @@ describe("loader", function() {
 			'module.exports = "Text <img src=\\"" + require("/test/image.png") + "\\">";'
 		);
 	});
+	it("should ignore hash fragments in URLs", function() {
+	    loader.call({}, '<img src="icons.svg#hash">').should.be.eql(
+	        'module.exports = "<img src=\\"" + require("./icons.svg") + "#hash\\">";'
+	    );
+	});
 });


### PR DESCRIPTION
A suggestion for how to leave URL hash fragments outside the require-statement instead of inside it. Fixes #15.