### PR TITLE
Update html-minifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"author": "Tobias Koppers @sokra",
 	"description": "html loader module for webpack",
 	"dependencies": {
-		"html-minifier": "0.5.x",
+		"html-minifier": "^0.7.2",
 		"source-map": "0.1.x",
 		"fastparse": "^1.0.0",
 		"loader-utils": "~0.2.2"

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -38,7 +38,7 @@ describe("loader", function() {
 		loader.call({
 			minimize: true
 		}, '<!-- comment --><h3>#{number} {customer}</h3>\n<p>   {title}   </p>\n\t <!-- comment --> <img src="image.png" />').should.be.eql(
-			'module.exports = "<h3>#{number} {customer}</h3><p>{title}</p><img src=" + require("./image.png") + ">";'
+			'module.exports = "<h3>#{number} {customer}</h3><p>{title}</p><img src=\\"" + require("./image.png") + "\\">";'
 		);
 	});
 	it("should not translate root-relative urls (without root query)", function() {


### PR DESCRIPTION
html-minifier has undergone a number of enhancements since 0.5. This PR simply updates the version to ^0.7.2 and fixes a test that failed with the new version. I've tested this patched version of html-loader with a large webpack project and things are good.

My main motivation for submitting this PR is one of the enhancements in the later versions of the module.  html-minifier now supports properly handling `<svg>` elements and knows not to remove trailing slashes from singleton elements within SVGs. SVGs included via html-loader are a big part of my team's webpack project and were showing some major issues when minification was turned on.

Thanks!