### PR TITLE
Added ":" to the list of allowed HTML attribute characters to support vuejs

### DIFF
--- a/lib/attributesParser.js
+++ b/lib/attributesParser.js
@@ -27,9 +27,9 @@ var parser = new Parser({
 	inside: {
 		"\\s+": true, // eat up whitespace
 		">": "outside", // end of attributes
-		"(([a-zA-Z\\-]+)\\s*=\\s*\")([^\"]*)\"": processMatch,
-		"(([a-zA-Z\\-]+)\\s*=\\s*\')([^\']*)\'": processMatch,
-		"(([a-zA-Z\\-]+)\\s*=\\s*)([^\\s>]+)": processMatch
+		"(([a-zA-Z\\-:]+)\\s*=\\s*\")([^\"]*)\"": processMatch,
+		"(([a-zA-Z\\-:]+)\\s*=\\s*\')([^\']*)\'": processMatch,
+		"(([a-zA-Z\\-:]+)\\s*=\\s*)([^\\s>]+)": processMatch
 	}
 });
 


### PR DESCRIPTION
Latest Vue.js syntax uses ":" characters in attributes, which is not supported in html-loader now. I added the support for these chars.