### PR TITLE
Add support for es6 interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ require("html?root=.!./fileB.html");
 
 ```
 
+## Interpolation
+
+You can use `interpolate` flag to enable interpolation syntax for ES6 template strings, like so:
+
+```
+require("html?interpolate!./file.html");
+```
+
+```
+<img src="${require(`./images/gallery.png`)}" />
+<div>${require('./partials/gallery.html')}</div>
+```
+
 ## License
 
 MIT (http://www.opensource.org/licenses/mit-license.php)

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "html loader module for webpack",
   "dependencies": {
+    "es6-templates": "^0.2.2",
     "fastparse": "^1.0.0",
     "html-minifier": "^0.7.2",
     "loader-utils": "~0.2.2",

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -74,4 +74,16 @@ describe("loader", function() {
 	        'module.exports = "<img src=\\"" + require("./icons.svg") + "#hash\\">";'
 	    );
 	});
+	it("should ignore interpolations by default", function() {
+			loader.call({}, '<img src="${"Hello " + (1+1)}">').should.be.eql(
+				'module.exports = "<img src=\\"${\\"Hello \\" + (1+1)}\\">";'
+			);
+	});
+	it("should enable interpolations when using interpolate flag", function() {
+			loader.call({
+				query: "?interpolate"
+			}, '<img src="${"Hello " + (1+1)}">').should.be.eql(
+				'module.exports = "<img src=\\"" + ("Hello " + (1 + 1)) + "\\">";'
+			);
+	});
 });


### PR DESCRIPTION
Hey,

I'm re-writing angular 1.0 app and I'd like to include partials directly from templates, like so:

```html
<div id="gallery">${require("./partials/gallery.html")}</div>
```

instead of relying on `ng-include`:

```html
<div id="gallery" ng-include="'partials/gallery.html'"></div>
```

This commit adds in 2 lines of JS support for es6 interpolation in any place of the template.

I find it very useful, I hope you too.