### PR TITLE
Allow to pass minimize options via query params 

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var attrParse = require("./lib/attributesParser");
 var SourceNode = require("source-map").SourceNode;
 var loaderUtils = require("loader-utils");
 var url = require("url");
+var assign = require("object-assign");
 
 function randomIdent() {
 	return "xxxHTMLLINKxxx" + Math.random() + Math.random() + "xxx";
@@ -57,16 +58,24 @@ module.exports = function(content) {
 	content.reverse();
 	content = content.join("");
 	if(typeof query.minimize === "boolean" ? query.minimize : this.minimize) {
-		content = htmlMinifier.minify(content, {
-			removeComments: query.removeComments !== false,
-			collapseWhitespace: query.collapseWhitespace !== false,
-			collapseBooleanAttributes: query.collapseBooleanAttributes !== false,
-			removeAttributeQuotes: query.removeAttributeQuotes !== false,
-			removeRedundantAttributes: query.removeRedundantAttributes !== false,
-			useShortDoctype: query.useShortDoctype !== false,
-			removeEmptyAttributes: query.removeEmptyAttributes !== false,
-			removeOptionalTags: query.removeOptionalTags !== false
+		var minimizeOptions = assign({}, query);
+
+		[
+			"removeComments",
+			"collapseWhitespace",
+			"collapseBooleanAttributes",
+			"removeAttributeQuotes",
+			"removeRedundantAttributes",
+			"useShortDoctype",
+			"removeEmptyAttributes",
+			"removeOptionalTags"
+		].forEach(function(name) {
+			if (typeof minimizeOptions[name] === "undefined") {
+				minimizeOptions[name] = true;
+			}
 		});
+
+		content = htmlMinifier.minify(content, minimizeOptions);
 	}
 	return "module.exports = " + JSON.stringify(content).replace(/xxxHTMLLINKxxx[0-9\.]+xxx/g, function(match) {
 		if(!data[match]) return match;

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "author": "Tobias Koppers @sokra",
   "description": "html loader module for webpack",
   "dependencies": {
-    "html-minifier": "^0.7.2",
-    "source-map": "0.1.x",
     "fastparse": "^1.0.0",
-    "loader-utils": "~0.2.2"
+    "html-minifier": "^0.7.2",
+    "loader-utils": "~0.2.2",
+    "object-assign": "^4.0.1",
+    "source-map": "0.1.x"
   },
   "devDependencies": {
     "mocha": "1.17.x",

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -38,7 +38,7 @@ describe("loader", function() {
 		loader.call({
 			minimize: true
 		}, '<!-- comment --><h3>#{number} {customer}</h3>\n<p>   {title}   </p>\n\t <!-- comment --> <img src="image.png" />').should.be.eql(
-			'module.exports = "<h3>#{number} {customer}</h3><p>{title}</p><img src=" + require("./image.png") + ">";'
+			'module.exports = "<h3>#{number} {customer}</h3><p>{title}</p><img src=\\"\" + require("./image.png") + "\\\">";'
 		);
 	});
 	it("should not translate root-relative urls (without root query)", function() {

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -37,8 +37,24 @@ describe("loader", function() {
 	it("should minimize", function() {
 		loader.call({
 			minimize: true
-		}, '<!-- comment --><h3>#{number} {customer}</h3>\n<p>   {title}   </p>\n\t <!-- comment --> <img src="image.png" />').should.be.eql(
-			'module.exports = "<h3>#{number} {customer}</h3><p>{title}</p><img src=\\"\" + require("./image.png") + "\\\">";'
+		}, '<!-- comment --><h3 customAttr="">#{number} {customer}</h3>\n<p>   {title}   </p>\n\t <!-- comment --> <img src="image.png" />').should.be.eql(
+			'module.exports = "<h3 customattr=\\"\\">#{number} {customer}</h3><p>{title}</p><img src=\\"\" + require("./image.png") + "\\\">";'
+		);
+	});
+	it("should preserve comments", function() {
+		loader.call({
+			minimize: true,
+			query: "?-removeComments"
+		}, '<!-- comment --><h3 customAttr="">#{number} {customer}</h3>\n<p>   {title}   </p>\n\t <!-- comment --> <img src="image.png" />').should.be.eql(
+			'module.exports = "<!-- comment --><h3 customattr=\\"\\">#{number} {customer}</h3><p>{title}</p><!-- comment --><img src=\\"\" + require("./image.png") + "\\\">";'
+		);
+	});
+	it("should treat attributes as case sensitive", function() {
+		loader.call({
+			minimize: true,
+			query: "?caseSensitive"
+		}, '<!-- comment --><h3 customAttr="">#{number} {customer}</h3>\n<p>   {title}   </p>\n\t <!-- comment --> <img src="image.png" />').should.be.eql(
+			'module.exports = "<h3 customAttr=\\"\\">#{number} {customer}</h3><p>{title}</p><img src=\\"\" + require("./image.png") + "\\\">";'
 		);
 	});
 	it("should not translate root-relative urls (without root query)", function() {


### PR DESCRIPTION
Provides query interface to pass any minification parameters to html-minifier in a manner of css-loader.

I've missed `caseSensitive` minifier option at html-loader query.