### PR TITLE
Update README.md, additional backslash needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ With this configuration:
 ``` javascript
 {
 	module: { loaders: [
-		{ test: "\.jpg$", loader: "file-loader" },
-		{ test: "\.png$", loader: "url-loader?mimetype=image/png" }
+		{ test: "\\.jpg$", loader: "file-loader" },
+		{ test: "\\.png$", loader: "url-loader?mimetype=image/png" }
 	]},
 	output: {
 		publicPath: "http://cdn.example.com/[hash]/"

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ With this configuration:
 ``` javascript
 {
 	module: { loaders: [
-		{ test: "\\.jpg$", loader: "file-loader" },
-		{ test: "\\.png$", loader: "url-loader?mimetype=image/png" }
+		{ test: /\.jpg$/, loader: "file-loader" },
+		{ test: /\.png$/, loader: "url-loader?mimetype=image/png" }
 	]},
 	output: {
 		publicPath: "http://cdn.example.com/[hash]/"


### PR DESCRIPTION
JSHint will complain about "\.jpg$", because JS will see that string as .jpg$, not \.jpg$