### PR TITLE
Safe set of minification defaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,13 +62,17 @@ module.exports = function(content) {
 
 		[
 			"removeComments",
+			"removeCommentsFromCDATA",
+			"removeCDATASectionsFromCDATA",
 			"collapseWhitespace",
-			"collapseBooleanAttributes",
+			"conservativeCollapse",
 			"removeAttributeQuotes",
-			"removeRedundantAttributes",
 			"useShortDoctype",
-			"removeEmptyAttributes",
-			"removeOptionalTags"
+			"keepClosingSlash",
+			"minifyJS",
+			"minifyCSS",
+			"removeScriptTypeAttributes",
+			"removeStyleTypeAttributes",
 		].forEach(function(name) {
 			if (typeof minimizeOptions[name] === "undefined") {
 				minimizeOptions[name] = true;


### PR DESCRIPTION
I've reviewed a few sources and tried to put a safe set of minification defaults 
that will not break common use cases such as some javascript and CSS use cases.
 I've used a subset of the "safe" options [from here](https://kangax.github.io/html-minifier/).

 Options not used are:

- Remove redundant attributes (can break styles/JS)
- Remove empty attributes (can break styles/JS)
- Remove empty elements (if the empty tag is indeed unintended it should be removed from the original)
- Minify URLs (seems like it should be at the users discretion to rewrite absolute URLs)

This addresses a number of issues: #40, #38.