### PR TITLE
Add support for complex config options

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,22 +14,31 @@ function randomIdent() {
 	return "xxxHTMLLINKxxx" + Math.random() + Math.random() + "xxx";
 };
 
+function getLoaderConfig(context) {
+	var query = loaderUtils.parseQuery(context.query);
+	var configKey = query.config || 'htmlLoader';
+	var config = context.options && context.options.hasOwnProperty(configKey) ? context.options[configKey] : {};
+
+	delete query.config;
+
+	return assign(query, config);
+}
 
 module.exports = function(content) {
 	this.cacheable && this.cacheable();
-	var query = loaderUtils.parseQuery(this.query);
+	var config = getLoaderConfig(this);
 	var attributes = ["img:src"];
-	if(query.attrs !== undefined) {
-		if(typeof query.attrs === "string")
-			attributes = query.attrs.split(" ");
-		else if(Array.isArray(query.attrs))
-			attributes = query.attrs;
-		else if(query.attrs === false)
+	if(config.attrs !== undefined) {
+		if(typeof config.attrs === "string")
+			attributes = config.attrs.split(" ");
+		else if(Array.isArray(config.attrs))
+			attributes = config.attrs;
+		else if(config.attrs === false)
 			attributes = [];
 		else
-			throw new Error("Invalid value to query parameter attrs");
+			throw new Error("Invalid value to config parameter attrs");
 	}
-	var root = query.root;
+	var root = config.root;
 	var links = attrParse(content, function(tag, attr) {
 		return attributes.indexOf(tag + ":" + attr) >= 0;
 	});
@@ -57,8 +66,8 @@ module.exports = function(content) {
 	});
 	content.reverse();
 	content = content.join("");
-	if(typeof query.minimize === "boolean" ? query.minimize : this.minimize) {
-		var minimizeOptions = assign({}, query);
+	if(typeof config.minimize === "boolean" ? config.minimize : this.minimize) {
+		var minimizeOptions = assign({}, config);
 
 		[
 			"removeComments",
@@ -78,7 +87,7 @@ module.exports = function(content) {
 		content = htmlMinifier.minify(content, minimizeOptions);
 	}
 
-	if (query.interpolate) {
+	if (config.interpolate) {
 		content = compile('`' + content + '`').code;
 	} else {
 		content = JSON.stringify(content);

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -57,6 +57,31 @@ describe("loader", function() {
 			'module.exports = "<h3 customAttr=\\"\\">#{number} {customer}</h3><p>{title}</p><img src=\\"\" + require("./image.png") + "\\\">";'
 		);
 	});
+	it("should accept complex options via a webpack config property", function() {
+		loader.call({
+			minimize: true,
+			options: {
+				htmlLoader: {
+					ignoreCustomFragments: [/\{\{.*?}}/]
+				}
+			}
+		}, '<h3>{{ count <= 1 ? "foo" : "bar" }}</h3>').should.be.eql(
+			'module.exports = "<h3>{{ count <= 1 ? \\"foo\\" : \\"bar\\" }}</h3>";'
+		);
+	});
+	it("should allow the webpack config property name to be configured", function() {
+		loader.call({
+			minimize: true,
+			options: {
+				htmlLoaderSuperSpecialConfig: {
+					ignoreCustomFragments: [/\{\{.*?}}/]
+				}
+			},
+			query: '?config=htmlLoaderSuperSpecialConfig'
+		}, '<h3>{{ count <= 1 ? "foo" : "bar" }}</h3>').should.be.eql(
+			'module.exports = "<h3>{{ count <= 1 ? \\"foo\\" : \\"bar\\" }}</h3>";'
+		);
+	});
 	it("should not translate root-relative urls (without root query)", function() {
 		loader.call({}, 'Text <img src="/image.png">').should.be.eql(
 			'module.exports = "Text <img src=\\"/image.png\\">";'


### PR DESCRIPTION
This PR add's a second method for passing config parameters to loader. Specifying them in the webpack configuration. This is necessary in order to be able to pass more complex arguments to the html minifier. In my case I wanted to specify `ignoreCustomFragments`, which is an array containing regexes. This is currently not possible within a simple query string.

If this gets merged, developers will be able to specify the loader options like this:

    // ...
    htmlLoader: {
        ignoreCustomFragments: [/\{\{.*?}}/]
    }
    // ...   

The property name can be configured via query, it defaults to `htmlLoader`

    html?config=htmlLoaderSuperSpecialConfig