### PR TITLE
[Improve] Show htmlMinifier error message in webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,10 @@ var url = require("url");
 var assign = require("object-assign");
 var compile = require("es6-templates").compile;
 
+function isError(target) {
+	return Object.prototype.toString.call(target)==='[object Error]'
+}
+
 function randomIdent() {
 	return "xxxHTMLLINKxxx" + Math.random() + Math.random() + "xxx";
 }
@@ -87,7 +91,16 @@ module.exports = function(content) {
 			}
 		});
 
-		content = htmlMinifier.minify(content, minimizeOptions);
+		try{
+			content = htmlMinifier.minify(content, minimizeOptions);
+		}catch(e){
+			if(!isError(e)){
+				throw new Error(e)
+			}else{
+				throw e;
+            }
+        }
+
 	}
 
 	if(config.interpolate) {

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -41,6 +41,14 @@ describe("loader", function() {
 			'module.exports = "<h3 customattr=\\"\\">#{number} {customer}</h3> <p> {title} </p>  <img src=\\"\" + require("./image.png") + "\\\"/>";'
 		);
 	});
+	it("should throw an Error in case of not closing tag", function() {
+		// #52
+		should.throws(function(){
+			loader.call({
+				minimize: true
+			}, '<h1>Hello World<h1');
+		},Error)
+	});
 	// https://github.com/webpack/webpack/issues/752
 	it("should not remove attributes by default", function() {
 		loader.call({


### PR DESCRIPTION
HtmlMinifier will throw a [string](https://github.com/kangax/html-minifier/blob/v1.2.0/src/htmlparser.js#L272) instead of an Error. Webpack will catch whatever is thrown.

 - if an Error is caught webpack will show its's message
 - if a string is thrown, webpack will show empty error message which is not helpful at all.
