### PR TITLE
chore(style): Bring code quality tooling inline with Webpack

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.js]
+indent_style=tab
+trim_trailing_whitespace=true

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,24 @@
+{
+	"env": {
+		"node": true
+	},
+	"rules": {
+		"strict": 0,
+		"camelcase": 0,
+		"curly": 0,
+		"indent": [2, "tab", { "SwitchCase": 1 }],
+		"eol-last": 1,
+		"no-shadow": 0,
+		"no-redeclare": 2,
+		"no-extra-bind": 1,
+		"no-empty": 0,
+		"no-process-exit": 1,
+		"no-underscore-dangle": 0,
+		"no-use-before-define": 0,
+		"no-unused-vars": 0,
+		"consistent-return": 0,
+		"no-inner-declarations": 1,
+		"no-loop-func": 1,
+		"space-before-function-paren": [2, "never"] 
+	}
+}

--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -1,0 +1,25 @@
+{
+  "js": {
+    "allowed_file_extensions": ["js", "json", "jshintrc", "jsbeautifyrc"],
+    "brace_style": "collapse",
+    "break_chained_methods": false,
+    "e4x": true,
+    "eval_code": false,
+    "end_with_newline": true,
+    "indent_char": "\t",
+    "indent_level": 0,
+    "indent_size": 1,
+    "indent_with_tabs": true,
+    "jslint_happy": false,
+    "jslint_happy_align_switch_case": true,
+    "space_after_anon_function": false,
+    "keep_array_indentation": false,
+    "keep_function_indentation": false,
+    "max_preserve_newlines": 2,
+    "preserve_newlines": true,
+    "space_before_conditional": false,
+    "space_in_paren": false,
+    "unescape_strings": false,
+    "wrap_line_length": 0
+  }
+}

--- a/lib/attributesParser.js
+++ b/lib/attributesParser.js
@@ -5,12 +5,12 @@
 var Parser = require("fastparse");
 
 var processMatch = function(match, strUntilValue, name, value, index) {
-    if(!this.isRelevantTagAttr(this.currentTag, name)) return;
-    this.results.push({
-        start: index + strUntilValue.length,
-        length: value.length,
-        value: value
-    });
+	if(!this.isRelevantTagAttr(this.currentTag, name)) return;
+	this.results.push({
+		start: index + strUntilValue.length,
+		length: value.length,
+		value: value
+	});
 };
 
 var parser = new Parser({
@@ -32,7 +32,6 @@ var parser = new Parser({
 		"(([0-9a-zA-Z\\-:]+)\\s*=\\s*)([^\\s>]+)": processMatch
 	}
 });
-
 
 module.exports = function parse(html, isRelevantTagAttr) {
 	return parser.parse("outside", html, {

--- a/package.json
+++ b/package.json
@@ -10,21 +10,22 @@
     "loader-utils": "~0.2.2",
     "object-assign": "^4.0.1"
   },
+  "license": "MIT",
   "devDependencies": {
+    "beautify-lint": "^1.0.4",
+    "eslint": "^3.1.1",
+    "js-beautify": "^1.6.3",
     "mocha": "^2.3.4",
     "should": "^7.1.1"
   },
   "scripts": {
-    "test": "mocha --reporter spec"
+    "pretest": "npm run lint && npm run beautify-lint",
+    "test": "mocha --reporter spec",
+    "lint": "eslint lib",
+    "beautify-lint": "beautify-lint lib/**/*.js test/**/*.js"
   },
   "repository": {
     "type": "git",
     "url": "git@github.com:webpack/html-loader.git"
-  },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/mit-license.php"
-    }
-  ]
+  }
 }

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -103,20 +103,20 @@ describe("loader", function() {
 		);
 	});
 	it("should ignore hash fragments in URLs", function() {
-	    loader.call({}, '<img src="icons.svg#hash">').should.be.eql(
-	        'module.exports = "<img src=\\"" + require("./icons.svg") + "#hash\\">";'
-	    );
+		loader.call({}, '<img src="icons.svg#hash">').should.be.eql(
+			'module.exports = "<img src=\\"" + require("./icons.svg") + "#hash\\">";'
+		);
 	});
 	it("should ignore interpolations by default", function() {
-			loader.call({}, '<img src="${"Hello " + (1+1)}">').should.be.eql(
-				'module.exports = "<img src=\\"${\\"Hello \\" + (1+1)}\\">";'
-			);
+		loader.call({}, '<img src="${"Hello " + (1+1)}">').should.be.eql(
+			'module.exports = "<img src=\\"${\\"Hello \\" + (1+1)}\\">";'
+		);
 	});
 	it("should enable interpolations when using interpolate flag", function() {
-			loader.call({
-				query: "?interpolate"
-			}, '<img src="${"Hello " + (1+1)}">').should.be.eql(
-				'module.exports = "<img src=\\"" + ("Hello " + (1 + 1)) + "\\">";'
-			);
+		loader.call({
+			query: "?interpolate"
+		}, '<img src="${"Hello " + (1+1)}">').should.be.eql(
+			'module.exports = "<img src=\\"" + ("Hello " + (1 + 1)) + "\\">";'
+		);
 	});
 });

--- a/test/parserTest.js
+++ b/test/parserTest.js
@@ -10,7 +10,9 @@ function test(name, html, result) {
 			if(tag === "div" && attr === "data-videomp4") return true;
 			if(tag === "use" && attr === "xlink:href") return true;
 			return false;
-		}).map(function(match) { return match.value }).should.be.eql(result);
+		}).map(function(match) {
+			return match.value
+		}).should.be.eql(result);
 	});
 }
 
@@ -36,7 +38,9 @@ describe("parser", function() {
 
 describe("locations", function() {
 	it("should report correct locations", function() {
-		attrParse('<img  src= "image.png">', function() { return true }).should.be.eql([{
+		attrParse('<img  src= "image.png">', function() {
+			return true
+		}).should.be.eql([{
 			start: 12,
 			length: 9,
 			value: "image.png"


### PR DESCRIPTION
 - Adds editorconfig
 - Adds eslint package and config
 - Adds jsBeautify and config
 - Adds lint npm script
 - Adds beautify-lint npm script
 - Adds pretest npm script to exec linting
 - Fixes existing linting errors

Resolves #71 