### PR TITLE
chore(ci): Bring validation tooling inline with Webpack

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.js]
+indent_style=tab
+trim_trailing_whitespace=true

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,24 @@
+{
+	"env": {
+		"node": true
+	},
+	"rules": {
+		"strict": 0,
+		"camelcase": 0,
+		"curly": 0,
+		"indent": [2, "tab", { "SwitchCase": 1 }],
+		"eol-last": 1,
+		"no-shadow": 0,
+		"no-redeclare": 2,
+		"no-extra-bind": 1,
+		"no-empty": 0,
+		"no-process-exit": 1,
+		"no-underscore-dangle": 0,
+		"no-use-before-define": 0,
+		"no-unused-vars": 0,
+		"consistent-return": 0,
+		"no-inner-declarations": 1,
+		"no-loop-func": 1,
+		"space-before-function-paren": [2, "never"]
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules
+coverage
+
 *.sw*
+
+npm-debug.log

--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -1,0 +1,26 @@
+
+{
+  "js": {
+    "allowed_file_extensions": ["js", "json", "jshintrc", "jsbeautifyrc"],
+    "brace_style": "collapse",
+    "break_chained_methods": false,
+    "e4x": true,
+    "eval_code": false,
+    "end_with_newline": true,
+    "indent_char": "\t",
+    "indent_level": 0,
+    "indent_size": 1,
+    "indent_with_tabs": true,
+    "jslint_happy": false,
+    "jslint_happy_align_switch_case": true,
+    "space_after_anon_function": false,
+    "keep_array_indentation": false,
+    "keep_function_indentation": false,
+    "max_preserve_newlines": 2,
+    "preserve_newlines": true,
+    "space_before_conditional": false,
+    "space_in_paren": false,
+    "unescape_strings": false,
+    "wrap_line_length": 0
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,16 @@
+sudo: false
 language: node_js
+os:
+  - linux
+  - osx
 node_js:
-  - 0.6
-  - 0.8
-  - 0.10
+  - node
+  - "6"
+  - "5"
+  - "4"
+
+script: npm run travis
+
+after_success:
+  - cat ./coverage/coverage.json | node_modules/codecov.io/bin/codecov.io.js
+  - rm -rf ./coverage

--- a/lib/attributesParser.js
+++ b/lib/attributesParser.js
@@ -5,12 +5,12 @@
 var Parser = require("fastparse");
 
 var processMatch = function(match, strUntilValue, name, value, index) {
-    if(!this.isRelevantTagAttr(this.currentTag, name)) return;
-    this.results.push({
-        start: index + strUntilValue.length,
-        length: value.length,
-        value: value
-    });
+	if(!this.isRelevantTagAttr(this.currentTag, name)) return;
+	this.results.push({
+		start: index + strUntilValue.length,
+		length: value.length,
+		value: value
+	});
 };
 
 var parser = new Parser({
@@ -32,7 +32,6 @@ var parser = new Parser({
 		"(([0-9a-zA-Z\\-:]+)\\s*=\\s*)([^\\s>]+)": processMatch
 	}
 });
-
 
 module.exports = function parse(html, isRelevantTagAttr) {
 	return parser.parse("outside", html, {

--- a/package.json
+++ b/package.json
@@ -11,11 +11,24 @@
     "object-assign": "^4.0.1"
   },
   "devDependencies": {
+    "beautify-lint": "^1.0.4",
+    "codecov.io": "^0.1.6",
+    "eslint": "^3.1.1",
+    "istanbul": "^0.4.4",
+    "js-beautify": "^1.6.3",
     "mocha": "^2.3.4",
     "should": "^7.1.1"
   },
   "scripts": {
-    "test": "mocha --reporter spec"
+    "pretest": "npm run lint && npm run beautify-lint",
+    "test": "mocha --harmony --full-trace --check-leaks",
+    "travis": "npm run cover -- --report lcovonly",
+    "lint": "eslint lib bin hot",
+    "beautify-lint": "beautify-lint lib/**/*.js hot/**/*.js bin/**/*.js benchmark/*.js test/*.js",
+    "beautify": "beautify-rewrite lib/**/*.js hot/**/*.js bin/**/*.js benchmark/*.js test/*.js",
+    "postcover": "npm run lint && npm run beautify-lint",
+    "cover": "istanbul cover -x *.runtime.js node_modules/mocha/bin/_mocha",
+    "publish-patch": "npm run lint && npm run beautify-lint && mocha && npm version patch && git push && git push --tags && npm publish"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "description": "html loader module for webpack",
   "dependencies": {
     "es6-templates": "^0.2.2",
-    "fastparse": "^1.0.0",
-    "html-minifier": "^1.0.0",
-    "loader-utils": "~0.2.2",
-    "object-assign": "^4.0.1"
+    "fastparse": "^1.1.1",
+    "html-minifier": "^3.0.1",
+    "loader-utils": "^0.2.15",
+    "object-assign": "^4.1.0"
   },
   "devDependencies": {
     "beautify-lint": "^1.0.4",
@@ -16,8 +16,8 @@
     "eslint": "^3.1.1",
     "istanbul": "^0.4.4",
     "js-beautify": "^1.6.3",
-    "mocha": "^2.3.4",
-    "should": "^7.1.1"
+    "mocha": "^2.5.3",
+    "should": "^10.0.0"
   },
   "scripts": {
     "pretest": "npm run lint && npm run beautify-lint",

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -103,20 +103,20 @@ describe("loader", function() {
 		);
 	});
 	it("should ignore hash fragments in URLs", function() {
-	    loader.call({}, '<img src="icons.svg#hash">').should.be.eql(
-	        'module.exports = "<img src=\\"" + require("./icons.svg") + "#hash\\">";'
-	    );
+		loader.call({}, '<img src="icons.svg#hash">').should.be.eql(
+			'module.exports = "<img src=\\"" + require("./icons.svg") + "#hash\\">";'
+		);
 	});
 	it("should ignore interpolations by default", function() {
-			loader.call({}, '<img src="${"Hello " + (1+1)}">').should.be.eql(
-				'module.exports = "<img src=\\"${\\"Hello \\" + (1+1)}\\">";'
-			);
+		loader.call({}, '<img src="${"Hello " + (1+1)}">').should.be.eql(
+			'module.exports = "<img src=\\"${\\"Hello \\" + (1+1)}\\">";'
+		);
 	});
 	it("should enable interpolations when using interpolate flag", function() {
-			loader.call({
-				query: "?interpolate"
-			}, '<img src="${"Hello " + (1+1)}">').should.be.eql(
-				'module.exports = "<img src=\\"" + ("Hello " + (1 + 1)) + "\\">";'
-			);
+		loader.call({
+			query: "?interpolate"
+		}, '<img src="${"Hello " + (1+1)}">').should.be.eql(
+			'module.exports = "<img src=\\"" + ("Hello " + (1 + 1)) + "\\">";'
+		);
 	});
 });

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -38,7 +38,7 @@ describe("loader", function() {
 		loader.call({
 			minimize: true
 		}, '<!-- comment --><h3 customAttr="">#{number} {customer}</h3>\n<p>   {title}   </p>\n\t <!-- comment --> <img src="image.png" />').should.be.eql(
-			'module.exports = "<h3 customattr=\\"\\">#{number} {customer}</h3> <p> {title} </p>  <img src=\\"\" + require("./image.png") + "\\\"/>";'
+			'module.exports = "<h3 customattr=\\"\\">#{number} {customer}</h3> <p> {title} </p> <img src=\" + require("./image.png") + \" />";'
 		);
 	});
 	// https://github.com/webpack/webpack/issues/752
@@ -46,7 +46,7 @@ describe("loader", function() {
 		loader.call({
 			minimize: true
 		}, '<input type="text" />').should.be.eql(
-			'module.exports = "<input type=\\"text\\"/>";'
+			'module.exports = "<input type=text />";'
 		);
 	});
 	it("should preserve comments", function() {
@@ -54,7 +54,7 @@ describe("loader", function() {
 			minimize: true,
 			query: "?-removeComments"
 		}, '<!-- comment --><h3 customAttr="">#{number} {customer}</h3><p>{title}</p><!-- comment --><img src="image.png" />').should.be.eql(
-			'module.exports = "<!-- comment --><h3 customattr=\\"\\">#{number} {customer}</h3><p>{title}</p><!-- comment --><img src=\\"\" + require("./image.png") + "\\\"/>";'
+			'module.exports = "<!-- comment --><h3 customattr=\\"\\">#{number} {customer}</h3><p>{title}</p><!-- comment --><img src=\" + require("./image.png") + \" />";'
 		);
 	});
 	it("should treat attributes as case sensitive", function() {
@@ -62,7 +62,7 @@ describe("loader", function() {
 			minimize: true,
 			query: "?caseSensitive"
 		}, '<!-- comment --><h3 customAttr="">#{number} {customer}</h3><p>{title}</p><!-- comment --><img src="image.png" />').should.be.eql(
-			'module.exports = "<h3 customAttr=\\"\\">#{number} {customer}</h3><p>{title}</p><img src=\\"\" + require("./image.png") + "\\\"/>";'
+			'module.exports = "<h3 customAttr=\\"\\">#{number} {customer}</h3><p>{title}</p><img src=\" + require("./image.png") + \" />";'
 		);
 	});
 	it("should accept complex options via a webpack config property", function() {

--- a/test/parserTest.js
+++ b/test/parserTest.js
@@ -10,7 +10,9 @@ function test(name, html, result) {
 			if(tag === "div" && attr === "data-videomp4") return true;
 			if(tag === "use" && attr === "xlink:href") return true;
 			return false;
-		}).map(function(match) { return match.value }).should.be.eql(result);
+		}).map(function(match) {
+			return match.value
+		}).should.be.eql(result);
 	});
 }
 
@@ -36,7 +38,9 @@ describe("parser", function() {
 
 describe("locations", function() {
 	it("should report correct locations", function() {
-		attrParse('<img  src= "image.png">', function() { return true }).should.be.eql([{
+		attrParse('<img  src= "image.png">', function() {
+			return true
+		}).should.be.eql([{
 			start: 12,
 			length: 9,
 			value: "image.png"


### PR DESCRIPTION
 - Adds editorconfig
 - Adds eslint package and config
 - Adds jsBeautify and config
 - Adds lint npm script
 - Adds beautify-lint npm script
 - Adds pretest npm script to exec linting
 - Fixes existing linting errors
 - Enable travis-ci node 4-6
   - Add linting to CI run
   - Add code coverage generation & reporting
- Fixes failing unit tests
- Updates project dependencies

Resolves #69 
Resolves #71 