### PR TITLE
only ${require('..')} to be translate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,22 @@ require("html?interpolate!./file.html");
 
 <div>${require('./components/gallery.html')}</div>
 ```
+And if you only want to use `require` in template and any other `${}` are not to be translate you can set `interpolate` flag to `require`, like so:
+
+```js
+require("html?interpolate=require!./file.ftl");
+```
+
+```html
+
+<#list list as list>
+  <a href="${list.href!}" />${list.name}</a>
+</#list>
+
+<img src="${require(`./images/gallery.png`)}">
+
+<div>${require('./components/gallery.html')}</div>
+```
 
 ### Advanced options
 

--- a/index.js
+++ b/index.js
@@ -118,13 +118,13 @@ module.exports = function(content) {
 
 		content = htmlMinifier.minify(content, minimizeOptions);
 	}
-	
+
 	if(config.interpolate && config.interpolate !== 'require') {
 		content = compile('`' + content + '`').code;
 	} else {
 		content = JSON.stringify(content);
 	}
-
+	
  	return "module.exports = " + content.replace(/xxxHTMLLINKxxx[0-9\.]+xxx/g, function(match) {
 		if(!data[match]) return match;
 		return '" + require(' + JSON.stringify(loaderUtils.urlToRequest(data[match], root)) + ') + "';

--- a/index.js
+++ b/index.js
@@ -66,7 +66,8 @@ module.exports = function(content) {
 	content.reverse();
 	content = content.join("");
 
-	if(config.interpolate){
+	if (config.interpolate === 'require'){
+
 		var reg = /\$\{require\([^)]*\)\}/g;
 		var result;
 		var reqList = [];
@@ -118,7 +119,11 @@ module.exports = function(content) {
 		content = htmlMinifier.minify(content, minimizeOptions);
 	}
 	
-	content = JSON.stringify(content);
+	if(config.interpolate && config.interpolate !== 'require') {
+		content = compile('`' + content + '`').code;
+	} else {
+		content = JSON.stringify(content);
+	}
 
  	return "module.exports = " + content.replace(/xxxHTMLLINKxxx[0-9\.]+xxx/g, function(match) {
 		if(!data[match]) return match;

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -119,4 +119,11 @@ describe("loader", function() {
 			'module.exports = "<img src=\\"" + ("Hello " + (1 + 1)) + "\\">";'
 		);
 	});
+	it("should enable interpolations when using interpolate=require flag and only require function to be translate", function() {
+		loader.call({
+			query: "?interpolate=require"
+		}, '<a href="${list.href}"><img src="${require(\'./test.jpg\')}" />').should.be.eql(
+			'module.exports = "<a href="${list.href}"><img src=\\"" + require(\'./test.jpg\') + "\\">";'
+		);
+	});
 });

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -123,7 +123,7 @@ describe("loader", function() {
 		loader.call({
 			query: "?interpolate=require"
 		}, '<a href="${list.href}"><img src="${require("./test.jpg")}" /></a>').should.be.eql(
-			'module.exports = "<a href="${list.href}"><img src=\\"" + require("./test.jpg") + "\\"></a>";'
+			'module.exports = "<a href=\"${list.href}\"><img src=\\"" + require("./test.jpg") + "\\" /></a>";'
 		);
 	});
 });

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -123,7 +123,7 @@ describe("loader", function() {
 		loader.call({
 			query: "?interpolate=require"
 		}, '<a href="${list.href}"><img src="${require("./test.jpg")}" /></a>').should.be.eql(
-			'module.exports = "<a href=\"${list.href}\"><img src=\\"" + require("./test.jpg") + "\\" /></a>";'
+			'module.exports = "<a href=\\"${list.href}\\"><img src=\\"" + require("./test.jpg") + "\\" /></a>";'
 		);
 	});
 });

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -122,8 +122,8 @@ describe("loader", function() {
 	it("should enable interpolations when using interpolate=require flag and only require function to be translate", function() {
 		loader.call({
 			query: "?interpolate=require"
-		}, '<a href="${list.href}"><img src="${require(\'./test.jpg\')}" />').should.be.eql(
-			'module.exports = "<a href="${list.href}"><img src=\\"" + require(\'./test.jpg\') + "\\">";'
+		}, '<a href="${list.href}"><img src="${require("./test.jpg")}" /></a>').should.be.eql(
+			'module.exports = "<a href="${list.href}"><img src=\\"" + require("./test.jpg") + "\\"></a>";'
 		);
 	});
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**
The template language has `${list.href}` flag when i use Freemarker template and i want to the loader to only translate `${require('..')}` and require that.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following... 

* Impact:
* Migration path for existing applications: 
* Github Issue(s) this is regarding:


**Other information**: