### PR TITLE
Mention extract loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,27 @@ module.exports = {
 };
 ```
 
+### Export into HTML files
+
+A very common scenario is exporting the HTML into their own _.html_ file, to
+serve them directly instead of injecting with javascript. This can be achieved
+with a combination of 3 loaders:
+
+- [file-loader](https://github.com/webpack/file-loader)
+- [extract-loader](https://github.com/peerigon/extract-loader)
+- html-loader
+
+The html-loader will parse the URLs, require the images and everything you
+expect. The extract loader will parse the javascript back into a proper html
+file and the file loader will write the _.html_ file for you. Example:
+
+```js
+{
+  test: /\.html$/,
+  loader: 'file-loader?name=[path][name].[ext]!extract-loader!html-loader'
+}
+```
+
 <h2 align="center">Maintainers</h2>
 
 <table>

--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ with a combination of 3 loaders:
 
 The html-loader will parse the URLs, require the images and everything you
 expect. The extract loader will parse the javascript back into a proper html
-file and the file loader will write the _.html_ file for you. Example:
+file, ensuring images are required and point to proper path, and the file loader
+will write the _.html_ file for you. Example:
 
 ```js
 {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Docs update

**What is the current behavior?** (You can also link to an open issue here)
extract-loader is not mentioned anywhere and it's extremely helpful to use html-loader in combination with file-loader. Allowing to require images, use full path and still output an _.html_ file.
https://github.com/webpack/html-loader/issues/62



**What is the new behavior?**
A section at the end of the documentation, mentioning the extract-loader and providing an example usage



**Does this PR introduce a breaking change?**
- [x] No
