### PR TITLE
adds ability to export module as es6 deafult export

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ require("html?interpolate=require!./file.ftl");
 <div>${require('./components/gallery.html')}</div>
 ```
 
+### Export format
+
+By default HTML is exported with ```module.exports```, but you can use ```exportAsEs6Default``` flag to export it as ES6 default export (via ```exports.default```)
+
 ### Advanced options
 
 If you need to pass [more advanced options](https://github.com/webpack/html-loader/pull/46), especially those which cannot be stringified, you can also define an `htmlLoader`-property on your `webpack.config.js`:

--- a/index.js
+++ b/index.js
@@ -125,7 +125,9 @@ module.exports = function(content) {
 		content = JSON.stringify(content);
 	}
 	
- 	return "module.exports = " + content.replace(/xxxHTMLLINKxxx[0-9\.]+xxx/g, function(match) {
+	var exportsString = config.exportAsEs6Default? "exports.default": "module.exports";
+	
+ 	return exportsString + " = " + content.replace(/xxxHTMLLINKxxx[0-9\.]+xxx/g, function(match) {
 		if(!data[match]) return match;
 		return '" + require(' + JSON.stringify(loaderUtils.urlToRequest(data[match], root)) + ') + "';
 	}) + ";";

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ module.exports = function(content) {
 	} else {
 		content = JSON.stringify(content);
 	}
-	
+
 	var exportsString = config.exportAsEs6Default? "exports.default": "module.exports";
 	
  	return exportsString + " = " + content.replace(/xxxHTMLLINKxxx[0-9\.]+xxx/g, function(match) {

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -126,4 +126,11 @@ describe("loader", function() {
 			'module.exports = "<a href=\\"${list.href}\\"><img src=\\"" + require("./test.jpg") + "\\" /></a>";'
 		);
 	});
+	it("should export as es6 default export", function() {
+		loader.call({
+			query: "?exportAsEs6Default"
+		}, '<p>Hello world!</p>').should.be.eql(
+			'exports.default = "<p>Hello world!</p>";'
+		);
+	});
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?**
currently html is exported via ```module.exports```

**What is the new behavior?**
adds ability to export html as es6 default export (via ```exports.default```) when ```exportAsEs6Default``` config param is set

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No
