### PR TITLE
adds "exportAsDefault"

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,13 @@ require("html?interpolate=require!./file.ftl");
 <div>${require('./components/gallery.html')}</div>
 ```
 
-### Export format
+### Export formats
 
-By default HTML is exported with ```module.exports```, but you can use ```exportAsEs6Default``` flag to export it as ES6 default export (via ```exports.default```)
+There are different export formats available:
+
++ ```module.exports``` (default, cjs format). "Hello world" becomes ```module.exports = "Hello world";```
++ ```exports.default``` (when ```exportAsDefault``` param is set, es6to5 format). "Hello world" becomes ```exports.default = "Hello world";```
++ ```exports default``` (when ```exportAsEs6Default``` param is set, es6 format). "Hello world" becomes ```exports default "Hello world";```
 
 ### Advanced options
 

--- a/index.js
+++ b/index.js
@@ -125,9 +125,15 @@ module.exports = function(content) {
 		content = JSON.stringify(content);
 	}
 
-	var exportsString = config.exportAsEs6Default? "exports.default": "module.exports";
-	
- 	return exportsString + " = " + content.replace(/xxxHTMLLINKxxx[0-9\.]+xxx/g, function(match) {
+    var exportsString = "module.exports = ";
+	if (config.exportAsDefault) {
+        exportsString = "exports.default = ";
+
+	} else if (config.exportAsEs6Default) {
+        exportsString = "exports default ";
+	}
+
+ 	return exportsString + content.replace(/xxxHTMLLINKxxx[0-9\.]+xxx/g, function(match) {
 		if(!data[match]) return match;
 		return '" + require(' + JSON.stringify(loaderUtils.urlToRequest(data[match], root)) + ') + "';
 	}) + ";";

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -126,18 +126,18 @@ describe("loader", function() {
 			'module.exports = "<a href=\\"${list.href}\\"><img src=\\"" + require("./test.jpg") + "\\" /></a>";'
 		);
 	});
-    it("should export as default export for es6to5 transpilation", function() {
-        loader.call({
-            query: "?exportAsDefault"
-        }, '<p>Hello world!</p>').should.be.eql(
-            'exports.default = "<p>Hello world!</p>";'
-        );
-    });
-    it("should export as es6 default export", function() {
-        loader.call({
-            query: "?exportAsEs6Default"
-        }, '<p>Hello world!</p>').should.be.eql(
-            'exports default "<p>Hello world!</p>";'
-        );
-    });
+	it("should export as default export for es6to5 transpilation", function() {
+		loader.call({
+			query: "?exportAsDefault"
+		}, '<p>Hello world!</p>').should.be.eql(
+			'exports.default = "<p>Hello world!</p>";'
+		);
+	});
+	it("should export as es6 default export", function() {
+		loader.call({
+			query: "?exportAsEs6Default"
+		}, '<p>Hello world!</p>').should.be.eql(
+			'exports default "<p>Hello world!</p>";'
+		);
+	});
 });

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -126,11 +126,18 @@ describe("loader", function() {
 			'module.exports = "<a href=\\"${list.href}\\"><img src=\\"" + require("./test.jpg") + "\\" /></a>";'
 		);
 	});
-	it("should export as es6 default export", function() {
-		loader.call({
-			query: "?exportAsEs6Default"
-		}, '<p>Hello world!</p>').should.be.eql(
-			'exports.default = "<p>Hello world!</p>";'
-		);
-	});
+    it("should export as default export for es6to5 transpilation", function() {
+        loader.call({
+            query: "?exportAsDefault"
+        }, '<p>Hello world!</p>').should.be.eql(
+            'exports.default = "<p>Hello world!</p>";'
+        );
+    });
+    it("should export as es6 default export", function() {
+        loader.call({
+            query: "?exportAsEs6Default"
+        }, '<p>Hello world!</p>').should.be.eql(
+            'exports default "<p>Hello world!</p>";'
+        );
+    });
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Feature

**What is the current behavior?**
currently we have 2 export formats: cjs (```module.exports =```, which is default), and "es6to5" (```exports.default =```, when ```exportAsEs6Default``` param is set)

**What is the new behavior?**
this PR changes behavior of  ```exportAsEs6Default``` param to actually export ES6 default export: ```exports default "hello world";```, and brings in another param (```exportAsDefault```) to export in es6to5 format: ```exports.default = "hello world";```

**Does this PR introduce a breaking change?**
- [x] No
