### PR TITLE
Update README to reflect Webpack 2 change to require -loader suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,28 +53,28 @@ With this configuration:
 ```
 
 ```js
-require("html!./file.html");
+require("html-loader!./file.html");
 
 // => '<img src="http://cdn.example.com/49eba9f/a992ca.png"
 //         data-src="image2x.png">'
 ```
 
 ```js
-require("html?attrs=img:data-src!./file.html");
+require("html-loader?attrs=img:data-src!./file.html");
 
 // => '<img src="image.png" data-src="data:image/png;base64,..." >'
 ```
 
 ```js
-require("html?attrs=img:src img:data-src!./file.html");
-require("html?attrs[]=img:src&attrs[]=img:data-src!./file.html");
+require("html-loader?attrs=img:src img:data-src!./file.html");
+require("html-loader?attrs[]=img:src&attrs[]=img:data-src!./file.html");
 
 // => '<img  src="http://cdn.example.com/49eba9f/a992ca.png"        
 //           data-src="data:image/png;base64,..." >'
 ```
 
 ```js
-require("html?-attrs!./file.html");
+require("html-loader?-attrs!./file.html");
 
 // => '<img  src="image.jpg"  data-src="image2x.png" >'
 ```
@@ -100,13 +100,13 @@ With the same configuration as above:
 ```
 
 ```js
-require("html!./file.html");
+require("html-loader!./file.html");
 
 // => '<img  src="/image.jpg">'
 ```
 
 ```js
-require("html?root=.!./file.html");
+require("html-loader?root=.!./file.html");
 
 // => '<img  src="http://cdn.example.com/49eba9f/a992ca.jpg">'
 ```
@@ -116,7 +116,7 @@ require("html?root=.!./file.html");
 You can use `interpolate` flag to enable interpolation syntax for ES6 template strings, like so:
 
 ```js
-require("html?interpolate!./file.html");
+require("html-loader?interpolate!./file.html");
 ```
 
 ```html
@@ -127,7 +127,7 @@ require("html?interpolate!./file.html");
 And if you only want to use `require` in template and any other `${}` are not to be translated, you can set `interpolate` flag to `require`, like so:
 
 ```js
-require("html?interpolate=require!./file.ftl");
+require("html-loader?interpolate=require!./file.ftl");
 ```
 
 ```html
@@ -158,7 +158,7 @@ module.exports = {
     loaders: [
       {
         test: /\.html$/,
-        loader: "html"
+        loader: "html-loader"
       }
     ]
   }
@@ -170,7 +170,7 @@ module.exports = {
 };
 ```
 
-If you need to define two different loader configs, you can also change the config's property name via `html?config=otherHtmlLoaderConfig`:
+If you need to define two different loader configs, you can also change the config's property name via `html-loader?config=otherHtmlLoaderConfig`:
 
 ```js
 module.exports = {
@@ -179,7 +179,7 @@ module.exports = {
     loaders: [
       {
         test: /\.html$/,
-        loader: "html?config=otherHtmlLoaderConfig"
+        loader: "html-loader?config=otherHtmlLoaderConfig"
       }
     ]
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:
Update to docs
**What is the current behavior?** (You can also link to an open issue here)
The current copy of the README.md occasionally uses the `-loader` suffix when showing examples of using `html-loader`, but most of the time simply uses the short form `html`. This will break as of Webpack v2.1.0-beta.26.


**What is the new behavior?**
Webpack v2.1.0-beta.26 introduced a breaking change to require loaders to have the `-loader` suffix. 
This PR updates the README to show that pattern as an example instead of using the shorthand naming.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following... 

* Impact:
* Migration path for existing applications: 
* Github Issue(s) this is regarding:


**Other information**:
