### PR TITLE
[export formats] fixes es6 default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ There are different export formats available:
 
 + ```module.exports``` (default, cjs format). "Hello world" becomes ```module.exports = "Hello world";```
 + ```exports.default``` (when ```exportAsDefault``` param is set, es6to5 format). "Hello world" becomes ```exports.default = "Hello world";```
-+ ```exports default``` (when ```exportAsEs6Default``` param is set, es6 format). "Hello world" becomes ```exports default "Hello world";```
++ ```export default``` (when ```exportAsEs6Default``` param is set, es6 format). "Hello world" becomes ```export default "Hello world";```
 
 ### Advanced options
 

--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ module.exports = function(content) {
         exportsString = "exports.default = ";
 
 	} else if (config.exportAsEs6Default) {
-        exportsString = "exports default ";
+        exportsString = "export default ";
 	}
 
  	return exportsString + content.replace(/xxxHTMLLINKxxx[0-9\.]+xxx/g, function(match) {

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -137,7 +137,7 @@ describe("loader", function() {
 		loader.call({
 			query: "?exportAsEs6Default"
 		}, '<p>Hello world!</p>').should.be.eql(
-			'exports default "<p>Hello world!</p>";'
+			'export default "<p>Hello world!</p>";'
 		);
 	});
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
there was an error in es6 default export format, that was exported as "export**s** default"

**What is the new behavior?**
now it's exported right way, as "export default"

**Does this PR introduce a breaking change?**
- [x] No
