### PR TITLE
Fix Maintainer section look

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,47 +235,55 @@ will write the _.html_ file for you. Example:
   <tbody>
     <tr>
       <td align="center">
-        <img width="150 height="150"
+        <img width="150" height="150"
         src="https://avatars.githubusercontent.com/u/18315?v=3">
+        </br>
         <a href="https://github.com/hemanth">Hemanth</a>
       </td>
       <td align="center">
-        <img width="150 height="150"
+        <img width="150" height="150"
         src="https://avatars.githubusercontent.com/u/8420490?v=3">
+        </br>
         <a href="https://github.com/d3viant0ne">Joshua Wiens</a>
       </td>
       <td align="center">
         <img width="150" height="150" src="https://avatars.githubusercontent.com/u/5419992?v=3">
+        </br>
         <a href="https://github.com/michael-ciniawsky">Michael Ciniawsky</a>
       </td>
       <td align="center">
         <img width="150" height="150"
         src="https://avatars.githubusercontent.com/u/6542274?v=3">
+        </br>
         <a href="https://github.com/imvetri">Imvetri</a>
       </td>
-    <tr>
+    </tr>
     <tr>
       <td align="center">
         <img width="150" height="150"
         src="https://avatars.githubusercontent.com/u/1520965?v=3">
+        </br>
         <a href="https://github.com/andreicek">Andrei Crnković</a>
       </td>
       <td align="center">
         <img width="150" height="150"
         src="https://avatars.githubusercontent.com/u/3367801?v=3">
+        </br>
         <a href="https://github.com/abouthiroppy">Yuta Hiroto</a>
       </td>
       <td align="center">
         <img width="150" height="150" src="https://avatars.githubusercontent.com/u/80044?v=3">
+        </br>
         <a href="https://github.com/petrunov">Vesselin Petrunov</a>
       </td>
       <td align="center">
         <img width="150" height="150"
         src="https://avatars.githubusercontent.com/u/973543?v=3">
+        </br>
         <a href="https://github.com/gajus">Gajus Kuizinas</a>
       </td>
-    <tr>
-  <tbody>
+    </tr>
+  </tbody>
 </table>
 
 <h2 align="center">LICENSE</h2>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Maintainers section HTML was incorrect, making the website look like this:
![image](https://cloud.githubusercontent.com/assets/1002461/22202717/66ebe0d0-e137-11e6-914d-03287f0c06de.png)



**What is the new behavior?**
![image](https://cloud.githubusercontent.com/assets/1002461/22202720/6aabc046-e137-11e6-8919-44c6f0a5ff74.png)



**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No